### PR TITLE
Fixing Firefox rednering issue

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-[*.js]
+[*]
 indent_size = 2
 
 [*.css]

--- a/tools/forms/editor.html
+++ b/tools/forms/editor.html
@@ -6,7 +6,6 @@
     <link rel="icon" href="data:,">
     <!-- Import DA App SDK -->
     <link rel="stylesheet" href="https://da.live/nx/styles/nexter.css">
-    <script src="https://da.live/nx/utils/sdk.js" type="module"></script>
     <script type="importmap">
       {
         "imports": {
@@ -14,6 +13,7 @@
         }
       }
     </script>
+    <script src="https://da.live/nx/utils/sdk.js" type="module"></script>
     <!-- Project App Logic -->
     <link rel="stylesheet" href="shared.css">
     <script src="editor.js" type="module"></script>


### PR DESCRIPTION
Seems that Firefox has an issue with importmap being defined after an import. Changed the order of the sdk.js import and the importmap.

Changing the editorconfig as well, to make indent size 2 the default for all files and keeping 4 for the css (as previously defined)
